### PR TITLE
[1pt] Switch badges for Rockets - Conditional components #5

### DIFF
--- a/src/components/RocketList.jsx
+++ b/src/components/RocketList.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
-import { reserveRocket } from '../redux/rockets/rocketsSlice';
+import { reserveRocket, cancelReserve } from '../redux/rockets/rocketsSlice';
 import { btnBookStyle, reservedStyle, btnCancelStyle } from './RocketBtnStyles';
 
 const RocketList = ({ item }) => {
@@ -11,8 +11,12 @@ const RocketList = ({ item }) => {
   } = item;
   const [firstImage] = rocketImage;
 
-  const handleClick = (id) => {
+  const reserveClick = (id) => {
     dispatch(reserveRocket(id));
+  };
+
+  const cancelClick = (id) => {
+    dispatch(cancelReserve(id));
   };
 
   return (
@@ -31,12 +35,12 @@ const RocketList = ({ item }) => {
         {
         item.reserved
           ? (
-            <button type="button" style={btnCancelStyle}>
+            <button type="button" style={btnCancelStyle} onClick={() => cancelClick(id)}>
               Cancel Reservation
             </button>
           )
           : (
-            <button type="button" onClick={() => handleClick(id)} style={btnBookStyle}>
+            <button type="button" onClick={() => reserveClick(id)} style={btnBookStyle}>
               Reserve Rocket
             </button>
           )

--- a/src/components/RocketList.jsx
+++ b/src/components/RocketList.jsx
@@ -15,7 +15,7 @@ const RocketList = ({ item }) => {
     dispatch(reserveRocket(id));
   };
 
-  const cancelClick = (id) => {
+  const cancelReserveClick = (id) => {
     dispatch(cancelReserve(id));
   };
 
@@ -35,7 +35,7 @@ const RocketList = ({ item }) => {
         {
         item.reserved
           ? (
-            <button type="button" style={btnCancelStyle} onClick={() => cancelClick(id)}>
+            <button type="button" style={btnCancelStyle} onClick={() => cancelReserveClick(id)}>
               Cancel Reservation
             </button>
           )

--- a/src/components/styles/RocketBtnStyles.jsx
+++ b/src/components/styles/RocketBtnStyles.jsx
@@ -1,0 +1,24 @@
+export const btnBookStyle = {
+  backgroundColor: '#007bff',
+  border: 0,
+  borderRadius: 4,
+  color: '#fff',
+  padding: 10,
+};
+
+export const reservedStyle = {
+  color: '#fff',
+  padding: 2,
+  backgroundColor: '#18a2b8',
+  borderRadius: 5,
+  fontSize: 10,
+  marginRight: 5,
+};
+
+export const btnCancelStyle = {
+  backgroundColor: '#fff',
+  border: '1px solid #000',
+  borderRadius: 4,
+  color: '#989ea3',
+  padding: 10,
+};

--- a/src/redux/rockets/rocketsSlice.js
+++ b/src/redux/rockets/rocketsSlice.js
@@ -31,6 +31,15 @@ const rocketsSlice = createSlice({
       });
       return { ...state, rockets: updatedRockets };
     },
+    cancelReserve: (state, { payload }) => {
+      const updatedRockets = state.rockets.map((rocket) => {
+        if (rocket.id === payload) {
+          return { ...rocket, reserved: false };
+        }
+        return rocket;
+      });
+      return { ...state, rockets: updatedRockets };
+    },
   },
   extraReducers: {
     [fetchRockets.pending]: (state) => ({ ...state, isLoading: true }),
@@ -43,6 +52,6 @@ const rocketsSlice = createSlice({
   },
 });
 
-export const { reserveRocket } = rocketsSlice.actions;
+export const { reserveRocket, cancelReserve } = rocketsSlice.actions;
 
 export default rocketsSlice.reducer;


### PR DESCRIPTION
Hi @maov19,

### **I have implemented the following requirements on this pull request;**

- Rockets that have already been reserved should show a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve rocket" (as per design)